### PR TITLE
Set font-family for readablity

### DIFF
--- a/internal/html/template.go
+++ b/internal/html/template.go
@@ -16,6 +16,7 @@ const treeTemplate = `<!DOCTYPE html>
 		<title>Coverage Report</title>
 		<style>
 			body {
+				font-family: "SF Mono", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
 				margin: 0;
 			}
 			.main {


### PR DESCRIPTION
Current implementation doesn't specify any font-family. If gover-html set the font-family, we get better look & feel.

AS-IS:
![screenshot-20250704T133346@2x](https://github.com/user-attachments/assets/a9e69aa3-56da-4c84-b723-a90d62f2ef1a)


TO-BE:
![screenshot-20250704T133305@2x](https://github.com/user-attachments/assets/44642881-ab04-440c-b7f8-b38d69e312d1)
